### PR TITLE
Avoid PHP error when things are weird

### DIFF
--- a/src/ParamDefinition.php
+++ b/src/ParamDefinition.php
@@ -478,7 +478,11 @@ class ParamDefinition implements IParamDefinition {
 	 * @param IParam[] $params
 	 */
 	public function format( IParam $param, array &$definitions, array $params ) {
-		if ( $this->isList() ) {
+		if ( $this->isList() && is_array( $param->getValue() ) ) {
+			// TODO: if isList returns true, the value should be an array.
+			// The second check here is to avoid a mysterious error.
+			// Should have logging that writes down the value whenever this occurs.
+
 			$values = $param->getValue();
 
 			foreach ( $values as &$value ) {


### PR DESCRIPTION
Fixes https://github.com/JeroenDeDauw/ParamProcessor/issues/16

Might break something else though... I'm not sure why a non-array
is ending up here, and what the value actually is. Is it null?
It it a single value? Is it a string with multiple values that
should have been split into an array?