### PR TITLE
Clear errors before processing

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -346,6 +346,10 @@ class Processor {
 	 * @since 0.4
 	 */
 	private function doParamProcessing() {
+
+		// Clear errors before processing any definitions
+		$this->errors = array();
+
 		$this->getParamsToProcess( [], $this->paramDefinitions );
 
 		while ( $this->paramsToHandle !== [] && !$this->hasFatalError() ) {


### PR DESCRIPTION
If the `Processor` instance is reused then ensure that errors from a previous processing are cleared. The issue came to light using `#info` [0] which internally relies on the `ParamProcessor`.

[0] https://sandbox.semantic-mediawiki.org/wiki/ParamProcessorInstanceError