### PR TITLE
Fix and add more specific PHPDoc type hints

### DIFF
--- a/src/IParamDefinition.php
+++ b/src/IParamDefinition.php
@@ -21,7 +21,7 @@ interface IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @param mixed $aliases string or array of string
+	 * @param string|string[] $aliases
 	 */
 	public function addAliases( $aliases );
 
@@ -31,7 +31,7 @@ interface IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @param mixed $dependencies string or array of string
+	 * @param string|string[] $dependencies
 	 */
 	public function addDependencies( $dependencies );
 
@@ -51,7 +51,7 @@ interface IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getAliases();
 
@@ -80,7 +80,7 @@ interface IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getDependencies();
 

--- a/src/Param.php
+++ b/src/Param.php
@@ -88,8 +88,6 @@ final class Param implements IParam {
 	protected $defaulted = false;
 
 	/**
-	 * The definition of the parameter.
-	 *
 	 * @since 1.0
 	 *
 	 * @var ParamDefinition
@@ -434,9 +432,7 @@ final class Param implements IParam {
 	}
 
 	/**
-	 * Returns false when there are no fatal errors or an ProcessingError when one is found.
-	 *
-	 * @return mixed false or ProcessingError
+	 * @return boolean
 	 */
 	public function hasFatalError() {
 		foreach ( $this->errors as $error ) {
@@ -497,7 +493,7 @@ final class Param implements IParam {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getAliases() {
 		return $this->definition->getAliases();

--- a/src/ParamDefinition.php
+++ b/src/ParamDefinition.php
@@ -68,7 +68,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $dependencies = [];
 
@@ -107,7 +107,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $aliases = [];
 
@@ -205,7 +205,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getAliases() {
 		return $this->aliases;
@@ -238,11 +238,11 @@ class ParamDefinition implements IParamDefinition {
 	}
 
 	/**
-	 * Returns the list of allowed values, or false if there is no such restriction.
+	 * Returns the list of allowed values, or an empty array if there is no such restriction.
 	 *
 	 * @since 1.0
 	 *
-	 * @return array|boolean false
+	 * @return array
 	 */
 	public function getAllowedValues() {
 		$allowedValues = [];
@@ -334,7 +334,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @param mixed $aliases string or array of string
+	 * @param string|string[] $aliases
 	 */
 	public function addAliases( $aliases ) {
 		$args = func_get_args();
@@ -346,7 +346,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @param mixed $dependencies string or array of string
+	 * @param string|string[] $dependencies
 	 */
 	public function addDependencies( $dependencies ) {
 		$args = func_get_args();
@@ -386,7 +386,7 @@ class ParamDefinition implements IParamDefinition {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getDependencies() {
 		return $this->dependencies;


### PR DESCRIPTION
There is an actual mistake in the documentation of `getAllowedValues`, everything else is just a bit more specific.