### PR TITLE
Do not rely on ValueValidator::setOptions in the interface

### DIFF
--- a/src/Param.php
+++ b/src/Param.php
@@ -349,7 +349,9 @@ final class Param implements IParam {
 		}
 		else {
 			$validator = $this->definition->getValueValidator();
-			$validator->setOptions( $this->definition->getOptions() ); // TODO
+			if ( method_exists( $validator, 'setOptions' ) ) {
+				$validator->setOptions( $this->definition->getOptions() );
+			}
 			$validationResult = $validator->validate( $value );
 
 			if ( !$validationResult->isValid() ) {

--- a/src/ParamDefinition.php
+++ b/src/ParamDefinition.php
@@ -248,8 +248,9 @@ class ParamDefinition implements IParamDefinition {
 		$allowedValues = [];
 
 		if ( $this->validator !== null && method_exists( $this->validator, 'getWhitelistedValues' ) ) {
-			// TODO: properly implement this
-			$this->validator->setOptions( $this->options );
+			if ( method_exists( $this->validator, 'setOptions' ) ) {
+				$this->validator->setOptions( $this->options );
+			}
 
 			$allowedValues = $this->validator->getWhitelistedValues();
 


### PR DESCRIPTION
This is just an intermediate step towards https://github.com/DataValues/Interfaces/pull/24. This will allow us to remove `setOptions` from the interface, but all relevant implementations will still have this method. This change allows for a non-breaking release of this ParamProcessor component.

Later this can be refactored further to not rely on these options any more, but to assume all validators are passed in with all relevant options already set. This will be a breaking change.