### PR TITLE
Allow '=' in positional parameters

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -163,10 +163,11 @@ class Processor {
 			// it is not a raw parameter, and can not be parsed correctly in all cases.
 			if ( is_string( $arg ) ) {
 				$parts = explode( '=', $arg, ( $nr <= $lastUnnamedDefaultNr ? 1 : 2 ) );
+				$paramName = trim( strtolower( $parts[0] ) );
 
 				// If there is only one part, no parameter name is provided, so try default parameter assignment.
 				// Default parameters having self::PARAM_UNNAMED set for having no name alias go here in any case.
-				if ( count( $parts ) == 1 ) {
+				if ( count( $parts ) == 1 || !in_array( $paramName, $defaultParams ) ) {
 					// Default parameter assignment is only possible when there are default parameters!
 					if ( count( $defaultParams ) > 0 ) {
 						$defaultParam = array_shift( $defaultParams );
@@ -176,7 +177,7 @@ class Processor {
 						$defaultParam = strtolower( $defaultParam );
 
 						$parameters[$defaultParam] = [
-							'original-value' => trim( $parts[0] ),
+							'original-value' => trim( $arg ),
 							'default' => $defaultNr,
 							'position' => $nr
 						];
@@ -186,7 +187,6 @@ class Processor {
 						// It might be nice to have some sort of warning or error here, as the value is simply ignored.
 					}
 				} else {
-					$paramName = trim( strtolower( $parts[0] ) );
 
 					$parameters[$paramName] = [
 						'original-value' => trim( $parts[1] ),


### PR DESCRIPTION
If a positional parameter contains a `=`, it will be split and erroneously recorded as named parameter.
Example for SMW: `{{#info: <span class="warning">Foobar!</span>}}`

This PR introduces an additional check to make sure that the assumed named parameter is actually defined and if not, record the parameter as positional.