### PR TITLE
Use explicit nullable type in DimensionParser constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ support the [Maps](https://github.com/JeroenDeDauw/Maps) and
 
 ## Release notes
 
+### 1.13.1
+
+* Added an explicit nullable type on the `DimensionParser::__construct` parameter, completing the PHP 8.4 deprecation fixes from 1.13.0
+
 ### 1.13.0 (2026-05-09)
 
 * Added explicit nullable types on `ProcessedParam::__construct`, `ParamDefinition::__construct`, and `ParamDefinitionFactory::__construct` parameters, fixing PHP 8.4 deprecation notices

--- a/src/PackagePrivate/DimensionParser.php
+++ b/src/PackagePrivate/DimensionParser.php
@@ -17,7 +17,7 @@ class DimensionParser implements ValueParser {
 
 	private $defaultUnit;
 
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$options = $options ?? new ParserOptions();
 
 		$this->defaultUnit = $options->hasOption( self::DEFAULT_UNIT ) ? $options->getOption( self::DEFAULT_UNIT ) : self::PIXELS;


### PR DESCRIPTION
`DimensionParser::__construct( ParserOptions $options = null )` uses the implicit-nullable parameter form, which is deprecated on PHP 8.4.

1.13.0 added explicit nullable types to the `ProcessedParam`, `ParamDefinition` and `ParamDefinitionFactory` constructors for exactly this reason, but `DimensionParser::__construct` was missed. This adds the `?` there too — the only remaining implicit-nullable signature in `src/`.

It doesn't surface in this library's own CI because its PHPUnit config does not escalate deprecation notices to errors. It does fail downstream under MediaWiki's test harness, which turns deprecations into errors — e.g. when a Semantic MediaWiki result format parses a `width`/`height` dimension on PHP 8.4+.